### PR TITLE
Call the Applet.AppletPopupMenu constructor directly.

### DIFF
--- a/capture@rjanja/applet.js
+++ b/capture@rjanja/applet.js
@@ -147,9 +147,7 @@ MyAppletPopupMenu.prototype = {
     __proto__: Applet.AppletPopupMenu.prototype,
 
     _init: function(launcher, orientation) {
-        PopupMenu.PopupMenu.prototype._init.call(this, launcher.actor, 0.0, orientation, 0);
-        Main.uiGroup.add_actor(this.actor);
-        this.actor.hide();
+        Applet.AppletPopupMenu.prototype._init.call(this, launcher, orientation);
     },
 
     addAction: function(title, callback) {


### PR DESCRIPTION
Hi,

I found a problem with your applet and my panel-rework branch, since I have modified the super class of your MyAppletPopupMenu class. If you just call the super-class constructor everything is fine again.
