### PR TITLE
Fix some JS warnings and imgur wizard for cinnamon 3.4

### DIFF
--- a/capture@rjanja/3.2/applet.js
+++ b/capture@rjanja/3.2/applet.js
@@ -1303,12 +1303,10 @@ MyApplet.prototype = {
 
          let image_file = Gio.file_new_for_path(screenshot.file);
          let image_uri = image_file.get_uri();
-         let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
          let image_texture = St.TextureCache.get_default().load_uri_sync(
             St.TextureCachePolicy.NONE,
             image_uri,
-            this._notificationImageSize, this._notificationImageSize,
-            scaleFactor);
+            this._notificationImageSize, this._notificationImageSize);
 
          //global.tex = image_texture;
 

--- a/capture@rjanja/3.2/applet.js
+++ b/capture@rjanja/3.2/applet.js
@@ -256,7 +256,7 @@ ScreenshotNotification.prototype = {
      // We hide all types of notifications once the user clicks on them because the common
      // outcome of clicking should be the relevant window being brought forward and the user's
      // attention switching to the window.
-     
+
      // if (!this.resident) {
      //     this.emit('done-displaying');
      //     global.log('destroying it');
@@ -433,7 +433,7 @@ MyApplet.prototype = {
       else if (this._uuid) {
          global.log(this._uuid + ': ' + msg);
       }
-      
+
    },
 
    _initSettings: function() {
@@ -448,7 +448,7 @@ MyApplet.prototype = {
          this.settings = new LocalSettings(this._uuid, this._instanceId);
          this._localSettings = true;
       }
-      
+
       this.settings.connect("settings-changed", Lang.bind(this, this._onSettingsChanged));
       this.settings.connect("changed::camera-program", Lang.bind(this, this._onRuntimeChanged));
       this.settings.connect("changed::recorder-program", Lang.bind(this, this._onRuntimeChanged));
@@ -526,7 +526,7 @@ MyApplet.prototype = {
             return this.run_cinnamon_camera(captureType, null, index);
          }
       });
-      
+
       // Read current value and if set, add the hotkey
       var curVal = this.settings.getValue(key);
       if (curVal != '' && curVal != null)
@@ -598,7 +598,7 @@ MyApplet.prototype = {
 
       this._notifLeftClickBehavior = this.settings.getValue('notif-image-left-click');
       this._notifRightClickBehavior = this.settings.getValue('notif-image-right-click');
-      
+
       this._showDeleteAction = this.settings.getValue('show-delete-action');
       this._showCopyPathAction = this.settings.getValue('show-copy-path-action');
       this._showCopyDataAction = this.settings.getValue('show-copy-data-action');
@@ -696,7 +696,7 @@ MyApplet.prototype = {
 
    _onMenuKeyPress: function(actor, event) {
       let symbol = event.get_key_symbol();
-      
+
       if (symbol == Clutter.Shift_L)
       {
          this.setModifier(symbol, true);
@@ -723,7 +723,7 @@ MyApplet.prototype = {
 
    _init: function(metadata, orientation, panelHeight, instanceId) {
       Applet.IconApplet.prototype._init.call(this, orientation);
-      
+
       try {
          this._programs = {};
          this._programSupport = {};
@@ -765,7 +765,7 @@ MyApplet.prototype = {
          this.openScreenshotsFolderItem = new Applet.MenuItem(_("Open screenshots folder"),
             'folder', Lang.bind(this, this._openScreenshotsFolder));
          this._applet_context_menu.addMenuItem(this.openScreenshotsFolderItem);
-         
+
          this.openRecordingsFolderItem = new Applet.MenuItem(_("Open recordings folder"),
             'folder', Lang.bind(this, this._openRecordingsFolder));
          this._applet_context_menu.addMenuItem(this.openRecordingsFolderItem);
@@ -801,7 +801,7 @@ MyApplet.prototype = {
          this._xfixesCursor = xfixesCursor;
 
          this.actor.add_style_class_name('desktop-capture');
-         
+
          this.set_applet_tooltip(_("Screenshot and desktop video"));
 
          this.draw_menu(orientation);
@@ -827,7 +827,7 @@ MyApplet.prototype = {
 
    _checkPaths: function(force) {
       force = force || false;
-      
+
       this.openScreenshotsFolderItem.setSensitive(
         false != this._getCreateFolder(this._cameraSaveDir, force));
 
@@ -910,13 +910,13 @@ MyApplet.prototype = {
          }
          else {
             this._outputTitle = new PopupMenu.PopupIconMenuItem(
-               _("Camera") + ": " + this.get_camera_option('title'), 
+               _("Camera") + ": " + this.get_camera_option('title'),
                "camera-photo", St.IconType.SYMBOLIC,
                { reactive: false });
          }
 
          this.menu.addMenuItem(this._outputTitle);
-         
+
          if (this.get_camera_program() == 'cinnamon') {
             let item = this.menu.addAction(this.indent(_("Window")), Lang.bind(this, function(e) {
                return this.run_cinnamon_camera(Screenshot.SelectionType.WINDOW, e);
@@ -935,7 +935,7 @@ MyApplet.prototype = {
             if (Main.layoutManager.monitors.length > 1) {
                Main.layoutManager.monitors.forEach(function(monitor, index) {
                   if (index < 3) {
-                    this.menu.addAction(this.indent(_("Monitor %d").format(index + 1)), 
+                    this.menu.addAction(this.indent(_("Monitor %d").format(index + 1)),
                      Lang.bind(this, function(e) {
                        return this.run_cinnamon_camera(Screenshot.SelectionType.MONITOR, e, index);
                     }), 'kb-cs-monitor-' + index);
@@ -944,7 +944,7 @@ MyApplet.prototype = {
             }
 
             this._redoMenuItem = this.menu.addAction(
-               this.indent(_("Repeat last")), 
+               this.indent(_("Repeat last")),
                Lang.bind(this, this.repeat_cinnamon_camera),
                this.settings.getValue('kb-cs-repeat'));
 
@@ -1024,7 +1024,7 @@ MyApplet.prototype = {
          optionSwitch.connect('toggled', Lang.bind(this, function(e1,v) {
             this._includeCursor = v;
             this.setSettingValue('include-cursor', v);
-            
+
             if (this.get_camera_program() == CAMERA_PROGRAM_GNOME
              && null !== this._ssSettings) {
                // We can't pass a cursor option to gnome-screenshot,
@@ -1067,7 +1067,7 @@ MyApplet.prototype = {
             this._send_test_notification();
          }));
       }*/
-      
+
 
       if (this.has_recorder())
       {
@@ -1077,9 +1077,9 @@ MyApplet.prototype = {
 
          if (this.has_recorder_option('gui')) {
             this._outputTitle2 = new PopupMenu.PopupIconMenuItem(
-               _("Recorder") + ": " + this.get_recorder_option('title'), 
+               _("Recorder") + ": " + this.get_recorder_option('title'),
                "media-record", St.IconType.SYMBOLIC);
-         
+
             let guiCommand = this.get_recorder_option('gui');
             this._outputTitle2.connect('activate', Lang.bind(this, function (menuItem, event) {
                this.Exec(guiCommand);
@@ -1087,16 +1087,16 @@ MyApplet.prototype = {
          }
          else {
             this._outputTitle2 = new PopupMenu.PopupIconMenuItem(
-               _("Recorder") + ": " + this.get_recorder_option('title'), 
+               _("Recorder") + ": " + this.get_recorder_option('title'),
                "media-record", St.IconType.SYMBOLIC, { reactive: false });
          }
-         
+
          this.menu.addMenuItem(this._outputTitle2);
 
          if (this.get_recorder_program() == 'cinnamon')
          {
              this._cRecorderItem = this.menu.addAction(
-               this.indent(_("Start recording")), 
+               this.indent(_("Start recording")),
                Lang.bind(this, this._toggle_cinnamon_recorder),
                this.settings.getValue('kb-recorder-stop'));
              // We could try to listen for when recording is activated
@@ -1116,7 +1116,7 @@ MyApplet.prototype = {
                   soundSwitch.connect('toggled', Lang.bind(this, function(e1,v) {
                      this._recordSound = v;
                      this.setSettingValue('record-sound', v);
-                     
+
                      return false;
                   }));
                   this.menu.addMenuItem(soundSwitch);
@@ -1306,8 +1306,8 @@ MyApplet.prototype = {
          let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
          let image_texture = St.TextureCache.get_default().load_uri_sync(
             St.TextureCachePolicy.NONE,
-            image_uri, 
-            this._notificationImageSize, this._notificationImageSize, 
+            image_uri,
+            this._notificationImageSize, this._notificationImageSize,
             scaleFactor);
 
          //global.tex = image_texture;
@@ -1329,7 +1329,7 @@ MyApplet.prototype = {
             //notification.addButton('custom', this._customActionLabel);
          //}
 
-         notification.connect('action-invoked', Lang.bind(this, function(n, action_id) { 
+         notification.connect('action-invoked', Lang.bind(this, function(n, action_id) {
             // global.log('Action invoked from notification: ' + action_id);
             return this.handleNotificationResponse(screenshot, action_id, n);
          }));
@@ -1522,7 +1522,7 @@ MyApplet.prototype = {
 
       let fnCapture = Lang.bind(this, function() {
          new Screenshot.ScreenshotHelper(type, Lang.bind(this, this.cinnamon_camera_complete),
-         { 
+         {
             includeCursor: this._includeCursor,
             useFlash: this._useCameraFlash,
             includeFrame: this._includeWindowFrame,
@@ -1621,7 +1621,7 @@ MyApplet.prototype = {
       {
          return false;
       }
-      
+
       let file = Gio.file_new_for_path(folderPath + '/' + fileName + '.' + fileExtension);
       let desiredFilepath = file.get_path();
       try {
@@ -1645,7 +1645,7 @@ MyApplet.prototype = {
       if (this.cRecorder.is_recording()) {
          this.cRecorder.pause();
          Meta.enable_unredirect_for_screen(global.screen);
-      
+
          if (!this._useSymbolicIcon) {
             this.set_applet_icon_path(ICON_FILE);
          }
@@ -1927,7 +1927,7 @@ MyApplet.prototype = {
       else {
          options = this.get_recorder_options();
       }
-      
+
       let cmd = options['custom'][custom];
 
       if (!cmd) {
@@ -2124,7 +2124,7 @@ MyApplet.prototype = {
 
       let accessToken, refreshToken, albumId;
 
-      let cmd = [ AppletDir + "/imgur-setup.js", AppletDir, 
+      let cmd = [ AppletDir + "/imgur-setup.js", AppletDir,
          this._imgurAccessToken, this._imgurRefreshToken, this._imgurAlbumId
       ].join(' ');
 
@@ -2275,7 +2275,7 @@ function main(metadata, orientation, panelHeight, instanceId) {
    Screenshot = imports.screenshot;
    Services = imports.services;
    AppUtil = imports.apputil;
-   
+
    SUPPORT_FILE = AppletDir + '/support.json';
    ICON_FILE = AppletDir + '/icon.png';
    ICON_FILE_ACTIVE = AppletDir + '/icon-active.png';

--- a/capture@rjanja/3.2/apputil.js
+++ b/capture@rjanja/3.2/apputil.js
@@ -77,7 +77,7 @@ function SpawnOpts(command, options) {
   });
 
   opts.logger('Running ' + command);
-  let pid, stdin, stdout, stderr, stream, reader, success, argv;
+  let res, pid, stdin, stdout, stderr, stream, reader, success, argv;
   [success,argv] = GLib.shell_parse_argv(command);
 
   try {

--- a/capture@rjanja/3.2/apputil.js
+++ b/capture@rjanja/3.2/apputil.js
@@ -82,7 +82,7 @@ function SpawnOpts(command, options) {
 
   try {
     [res, pid, stdin, stdout, stderr] = GLib.spawn_async_with_pipes(
-      null, argv, null, GLib.SpawnFlags.SEARCH_PATH  | GLib.SpawnFlags.DO_NOT_REAP_CHILD, null);    
+      null, argv, null, GLib.SpawnFlags.SEARCH_PATH  | GLib.SpawnFlags.DO_NOT_REAP_CHILD, null);
   }
   catch (e) {
     opts.logger("Failure creating process");
@@ -94,7 +94,7 @@ function SpawnOpts(command, options) {
     opts.onSpawn(pid);
 
     stream = new Gio.DataInputStream({ base_stream : new Gio.UnixInputStream({ fd : stdout }) });
-    
+
     if (typeof opts.onLineOut == 'function') {
       this.read = function(stream, func) {
         stream.read_line_async(GLib.PRIORITY_LOW, null, Lang.bind(this, function(source, result) {

--- a/capture@rjanja/3.2/imgur-setup.js
+++ b/capture@rjanja/3.2/imgur-setup.js
@@ -156,7 +156,7 @@ const ImgurWizard = new Lang.Class ({
     var pinLabel = new Gtk.Label({ label: 'PIN:' });
     pinLabel.set_justify(Gtk.Justification.RIGHT);
     pinLabel.set_alignment(1.0, 0.5);
-    box2.pack_start(pinLabel, false, true, 5);      
+    box2.pack_start(pinLabel, false, true, 5);
     this._pinEntry = new Gtk.Entry();
     this._pinEntry.set_alignment(0.0, 0.5);
     this._pinEntry.set_max_width_chars(32);
@@ -166,7 +166,7 @@ const ImgurWizard = new Lang.Class ({
     // box2.set_margin(10);
     box.pack_start(box2, true, true, 5);
 
-    
+
     let box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 0 });
     this._stack.add_titled(box, '4', _('Choose album'));
     let instructionsText = _('Please choose the album for new screenshots.');
@@ -357,7 +357,7 @@ const ImgurWizard = new Lang.Class ({
   },
 
   verifyPin: function() {
-    
+
   },
 
   _showPinError: function (errorText) {
@@ -391,7 +391,7 @@ function main(argv) {
   initEnvironment();
   imports.searchPath.push(argv[0]);
   imports.searchPath.push('/usr/share/cinnamon/js');
-  
+
   Services = imports.services;
   // AppUtil = imports.apputil;
 

--- a/capture@rjanja/3.2/imgur-setup.js
+++ b/capture@rjanja/3.2/imgur-setup.js
@@ -138,7 +138,7 @@ const ImgurWizard = new Lang.Class ({
     instructionsLabel3.set_padding(10, 10);
     box.pack_start(instructionsLabel3, false, false, 5);
 
-    let box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 0 });
+    box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 0 });
     this._stack.add_titled(box, '3', _('Validate PIN'));
     let instructionsText = _('Enter PIN to validate access and get tokens.');
     let instructionsLabel = new Gtk.Label({ label: instructionsText, use_markup: true});
@@ -167,10 +167,10 @@ const ImgurWizard = new Lang.Class ({
     box.pack_start(box2, true, true, 5);
 
 
-    let box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 0 });
+    box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 0 });
     this._stack.add_titled(box, '4', _('Choose album'));
-    let instructionsText = _('Please choose the album for new screenshots.');
-    let instructionsLabel = new Gtk.Label({ label: instructionsText, use_markup: true});
+    instructionsText = _('Please choose the album for new screenshots.');
+    instructionsLabel = new Gtk.Label({ label: instructionsText, use_markup: true});
     instructionsLabel.set_padding(10, 10);
     instructionsLabel.set_justify(Gtk.Justification.LEFT);
     instructionsLabel.set_alignment(0, 0);
@@ -200,10 +200,10 @@ const ImgurWizard = new Lang.Class ({
     box.pack_start(subLabel, false, false, 5);
 
 
-    let box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 0 });
+    box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 0 });
     this._stack.add_titled(box, '5', _('Finished'));
-    let instructionsText = _('All done!');
-    let instructionsLabel = new Gtk.Label({ label: instructionsText, use_markup: true});
+    instructionsText = _('All done!');
+    instructionsLabel = new Gtk.Label({ label: instructionsText, use_markup: true});
     instructionsLabel.set_padding(10, 10);
     instructionsLabel.set_justify(Gtk.Justification.LEFT);
     instructionsLabel.set_alignment(0, 0);

--- a/capture@rjanja/3.2/screenshot.js
+++ b/capture@rjanja/3.2/screenshot.js
@@ -400,10 +400,10 @@ ScreenshotHelper.prototype = {
          y_align: St.Align.START
       });
 
-      this.container.add_actor(this.border1, {expand: false, x_fill: false});
-      this.container.add_actor(this.border2, {expand: false, x_fill: false});
-      this.container.add_actor(this.border3, {expand: false, x_fill: false});
-      this.container.add_actor(this.border4, {expand: false, x_fill: false});
+      this.container.add_actor(this.border1);
+      this.container.add_actor(this.border2);
+      this.container.add_actor(this.border3);
+      this.container.add_actor(this.border4);
 
       this.handle1 = new St.Bin({ style_class: 'handle', name: 'handleNw', reactive: true });
       this.handle2 = new St.Bin({ style_class: 'handle', name: 'handleN', reactive: true });

--- a/capture@rjanja/3.2/screenshot.js
+++ b/capture@rjanja/3.2/screenshot.js
@@ -1,5 +1,5 @@
 /**
- * Cinnamon Screenshot class to support capture selection and 
+ * Cinnamon Screenshot class to support capture selection and
  * communication with back-end screencapture program.
  *
  * @author  Rob Adams <pillage@gmail.com>
@@ -88,7 +88,7 @@ ScreenshotHelper.prototype = {
       };
 
       this.setOptions(params);
-      
+
       global.log("Initializing screenshot tool");
 
       this._xfixesCursor = Cinnamon.XFixesCursor.get_for_stage(global.stage);
@@ -198,7 +198,7 @@ ScreenshotHelper.prototype = {
       }
       else {
          onFinished();
-      }   
+      }
    },
 
    _setTimer: function(timeout) {
@@ -287,7 +287,7 @@ ScreenshotHelper.prototype = {
          this.screenshotMonitor();
       })));
    },
-   
+
    selectCinnamon: function() {
       this._modal = true;
       this._target = null;
@@ -373,26 +373,26 @@ ScreenshotHelper.prototype = {
          return;
       }
 
-      this.border1 = new St.Bin({ 
+      this.border1 = new St.Bin({
          style_class: 'border-h',
          x_fill: true,
          y_fill: false,
          y_align: St.Align.START
       });
-      this.border2 = new St.Bin({ 
+      this.border2 = new St.Bin({
          style_class: 'border-h',
          x_fill: true,
          y_fill: false,
          y_align: St.Align.END
       });
-      this.border3 = new St.Bin({ 
+      this.border3 = new St.Bin({
          style_class: 'border-v',
          x_fill: false,
          y_fill: true,
          x_align: St.Align.START,
          y_align: St.Align.START
       });
-      this.border4 = new St.Bin({ 
+      this.border4 = new St.Bin({
          style_class: 'border-v',
          x_fill: false,
          y_fill: true,
@@ -423,7 +423,7 @@ ScreenshotHelper.prototype = {
       this.container.add_actor(this.handle7);
       this.container.add_actor(this.handle8);
 
-      
+
       this.initializeShadow();
       this.drawShadows(0, 0, 0, 0);
 
@@ -455,11 +455,11 @@ ScreenshotHelper.prototype = {
          this.instructionsContainer.destroy();
          this.instructionsContainer = null;
          return true;
-      } 
+      }
       else {
          return false;
       }
-   }, 
+   },
 
    showInstructions: function(cssExtra) {
       let [x, y, mask] = global.get_pointer();
@@ -527,7 +527,7 @@ ScreenshotHelper.prototype = {
          reactive: false,
          style_class: 'shadow-container'
       });
-      
+
       Main.uiGroup.add_actor(this.shadowContainer);
 
       this.coverLeft = new St.Bin({
@@ -550,7 +550,7 @@ ScreenshotHelper.prototype = {
          x_fill: true,
          y_fill: true
       });
-      
+
       this.shadowContainer.add_actor(this.coverLeft);
       this.shadowContainer.add_actor(this.coverRight);
       this.shadowContainer.add_actor(this.coverTop);
@@ -672,12 +672,12 @@ ScreenshotHelper.prototype = {
       let filename = this.getFilename(opts);
 
       let monitor = Main.layoutManager.monitors[opts.useIndex];
-      
+
       // Call capture back-end.
       let screenshot = new Cinnamon.Screenshot();
-      screenshot.screenshot_area (opts.includeCursor, 
-                                  monitor.x, monitor.y, 
-                                  monitor.width, monitor.height, 
+      screenshot.screenshot_area (opts.includeCursor,
+                                  monitor.x, monitor.y,
+                                  monitor.width, monitor.height,
                                   filename,
          Lang.bind(this, function() {
             this.runCallback({
@@ -693,7 +693,7 @@ ScreenshotHelper.prototype = {
       return true;
    },
 
-   
+
 
    screenshotCinnamon: function(actor, stageX, stageY, options) {
       //global.log('screenshotCinnamon() [actor,stageX,stageY]');
@@ -703,7 +703,7 @@ ScreenshotHelper.prototype = {
          this.reset();
          return false;
       }
-      
+
       // Reset after a short delay so we don't activate the actor we
       // have clicked.
       let timeoutId = Mainloop.timeout_add(200, Lang.bind(this, function() {
@@ -911,14 +911,14 @@ ScreenshotHelper.prototype = {
          }
          this._eventHandler = null;
       }
-      
+
       if (this.shadowContainer) {
          Main.uiGroup.remove_actor(this.shadowContainer);
          this.shadowContainer.destroy();
       }
 
       this.hideInstructions();
-      
+
       if (this._timer) {
          Main.uiGroup.remove_actor(this._timer);
          this._timer.destroy();
@@ -1040,8 +1040,8 @@ ScreenshotHelper.prototype = {
                return true;
             }
             else if (this._selectionMade) {
-               let isMovementKey = (sym == Clutter.KEY_Up 
-                   || sym == Clutter.KEY_Down || sym == Clutter.KEY_Left 
+               let isMovementKey = (sym == Clutter.KEY_Up
+                   || sym == Clutter.KEY_Down || sym == Clutter.KEY_Left
                    || sym == Clutter.KEY_Right);
 
                if (isMovementKey) {
@@ -1301,7 +1301,7 @@ ScreenshotHelper.prototype = {
                   x = Math.min(this._xEnd, this._xStart);
                   y = Math.min(this._yEnd, this._yStart);
                }
-               
+
                this.redrawAreaSelection(x, y);
             }
          } else if (type == Clutter.EventType.BUTTON_RELEASE) {
@@ -1332,9 +1332,9 @@ ScreenshotHelper.prototype = {
 
                [this._xStart, this._yStart] = this.container.get_position();
                [this._xEnd, this._yEnd] = [this._xStart + width, this._yStart + height];
-               
+
                this._mouseDown = false;
-               
+
                this._selectionMade = true;
 
                //if (this._xEnd == -1 || this._yEnd == -1 || (width < 5 && height < 5)) {
@@ -1420,11 +1420,11 @@ ScreenshotHelper.prototype = {
       Main.uiGroup.remove_actor(this.uiContainer);
       this.uiContainer.destroy();
 
-      
+
       this.container.remove_actor(this._outlineBackground);
       this._outlineBackground.destroy();
       this._outlineBackground = null;
-      
+
       this.container.remove_actor(this._outlineFrame);
       this._outlineFrame.destroy();
 

--- a/capture@rjanja/3.2/services.js
+++ b/capture@rjanja/3.2/services.js
@@ -46,7 +46,7 @@ Imgur.prototype = {
   getAlbumsUrl: function() {
     return "https://api.imgur.com/3/account/me/albums.json";
   },
-  
+
   requestAlbumList: function(onFailure, onSuccess, limit) {
     let headers = {
       'Authorization': 'Bearer ' + this.accessToken,
@@ -190,9 +190,9 @@ Imgur.prototype = {
           var imgur = JSON.parse(response.response_body.data);
           if (imgur['success']) {
             let linkText = 't=' + new Date(new Date().getTime()).toISOString()
-              + ': ' + imgur['data']['link'] + ' ' 
+              + ': ' + imgur['data']['link'] + ' '
               + imgur['data']['deletehash'] + '\n';
-            imgLog.write(linkText, null);      
+            imgLog.write(linkText, null);
             callback(true, imgur['data']);
             return true;
           }
@@ -237,7 +237,7 @@ Imgur.prototype = {
 
       let buffer = new Soup.Buffer(contents, contents.length);
       let multiPart = new Soup.Multipart(Soup.FORM_MIME_TYPE_MULTIPART);
-      
+
       multiPart.append_form_file('image', filename, 'image/png', buffer);
       for (key in params) {
         multiPart.append_form_string(key, params[key]);


### PR DESCRIPTION
The first commit removes some trailing spaces (I use atom, which removes them automatically. To make review easier I put this into a separate commit).

The second commit fixes some JS warnings. Closes #74 

The third commit fixes #75 
In Cinnamon 3.4 the [CJS Javascript interpreter was rebased and now runs on mozjs 38.](https://www.linuxmint.com/rel_sonya_cinnamon_whatsnew.php) It causes js to crash, if a variable is declared twice within the same scope. Removing those duplicate `let` declarations and the wizard starts as expected.

And the `res` variable was undeclared.