### PR TITLE
Fix icon size for custom panelHeight

### DIFF
--- a/capture@rjanja/3.6/applet.js
+++ b/capture@rjanja/3.6/applet.js
@@ -819,7 +819,7 @@ MyApplet.prototype = {
     },
 
    _init: function(metadata, orientation, panelHeight, instanceId) {
-      Applet.IconApplet.prototype._init.call(this, orientation);
+      Applet.IconApplet.prototype._init.call(this, orientation, panelHeight, instanceId);
 
       try {
          this._programs = {};


### PR DESCRIPTION
If you use a custom height for your panel the icon scales properly, but as soon as you restart Cinnamon, the icon gets back it's default size. This will fix this issue.